### PR TITLE
Provides a fix for URI parsing exceptions InvalidURIError

### DIFF
--- a/lib/duck_duck_go/zero_click_info.rb
+++ b/lib/duck_duck_go/zero_click_info.rb
@@ -42,14 +42,14 @@ module DuckDuckGo
       abstract = result['Abstract'] unless result['Abstract'].empty?
       abstract_text = result['AbstractText'] unless result['AbstractText'].empty?
       abstract_source = result['AbstractSource'] unless result['AbstractSource'].empty?
-      abstract_url = URI.parse(result['AbstractURL']) unless result['AbstractURL'].empty?
-      image = URI.parse(result['Image']) unless result['Image'].empty?
+      abstract_url = URI.parse(URI.escape(result['AbstractURL'])) unless result['AbstractURL'].empty?
+      image = URI.parse(URI.escape(result['Image'])) unless result['Image'].empty?
       heading = result['Heading'] unless result['Heading'].empty?
       answer = result['Answer'] unless result['Answer'].empty?
       answer_type = result['AnswerType'] unless result['AnswerType'].empty?
       definition = result['Definition'] unless result['Definition'].empty?
       definition_source = result['DefinitionSource'] unless result['DefinitionSource'].empty?
-      definition_url = URI.parse(result['DefinitionURL']) unless result['DefinitionURL'].empty?
+      definition_url = URI.parse(URI.escape(result['DefinitionURL'])) unless result['DefinitionURL'].empty?
       type = result['Type'] unless result['Type'].empty?
       
       if result['Results']

--- a/test/tc_zero_click_info.rb
+++ b/test/tc_zero_click_info.rb
@@ -799,7 +799,7 @@ class TestZCI < Test::Unit::TestCase
  "AbstractURL"=>"http://en.wikipedia.org/wiki/Lorem_Ipsum",
  "Image"=>"",
  "DefinitionURL"=>
-  "http://www.thefreedictionary.com/_/search.aspx?pid=aff18&word=lorem%2520ipsum",
+  "http://www.merriam-webster.com/dictionary/lorem ipsum",
  "DefinitionSource"=>"TheFreeDictionary",
  "AbstractText"=>"",
  "Type"=>"E"}


### PR DESCRIPTION
This is from actual usage with DDG. It is possible to get URIs that
contain spaces in them and are unescpaed. I assume it is also possible
they could contain other special characters unescaped. It makes sense to
escape the values to ensure they are 'clean'.

Specific example search was "Video Games"
