### PR TITLE
Adding 'no_redirect=1' argument to http requests

### DIFF
--- a/lib/duck_duck_go.rb
+++ b/lib/duck_duck_go.rb
@@ -36,7 +36,8 @@ module DuckDuckGo
     def zeroclickinfo(query, skip_disambiguation = false)
       args = {
         'q' => query,
-        'o' => 'json'
+        'o' => 'json',
+        'no_redirect' => 1
       }
       if(skip_disambiguation)
         args['d'] = 1


### PR DESCRIPTION
Hi Andrew,

I had an issue with the DuckDuckGo `!bang` syntax, which usually redirects to other websites (e.g. https://ddg.gg/?q=!w+duckduckgo redirects to DuckDuckGo on Wikipedia):
`ddg.zeroclickinfo("!w duckduckgo")` would return source HTML from Wikipedia instead of a redirection link from DuckDuckGo.

I fixed it by adding a `no_redirect=1` HTTP argument to the request, based on following API example from the API page: https://api.duckduckgo.com/?q=!imdb+rushmore&format=json&pretty=1&no_redirect=1. `no_redirect=1` is added whether or not `!bang` syntax is used, but it does not seem to modify anything for other (non-redirected) results.
