### PR TITLE
Support for redirect links (through !bang syntax)

### DIFF
--- a/lib/duck_duck_go.rb
+++ b/lib/duck_duck_go.rb
@@ -36,7 +36,8 @@ module DuckDuckGo
     def zeroclickinfo(query, skip_disambiguation = false)
       args = {
         'q' => query,
-        'o' => 'json'
+        'o' => 'json',
+        'no_redirect' => 1
       }
       if(skip_disambiguation)
         args['d'] = 1

--- a/lib/duck_duck_go/zero_click_info.rb
+++ b/lib/duck_duck_go/zero_click_info.rb
@@ -52,7 +52,7 @@ module DuckDuckGo
       definition_source = result['DefinitionSource'] unless result['DefinitionSource'].empty?
       definition_url = URI.parse(URI.escape(result['DefinitionURL'])) unless result['DefinitionURL'].empty?
       type = result['Type'] unless result['Type'].empty?
-      redirect = result['Redirect'] unless result['Redirect'].empty?
+      redirect = URI.parse(URI.escape(result['Redirect'])) unless result['Redirect'].empty?
       
       if result['Results']
         results = Array.new

--- a/lib/duck_duck_go/zero_click_info.rb
+++ b/lib/duck_duck_go/zero_click_info.rb
@@ -15,10 +15,10 @@ module DuckDuckGo
       'E' => 'exclusive',
     }
     
-    attr_reader :abstract, :abstract_text, :abstract_source, :abstract_url, :image, :heading, :answer, :answer_type, :definition, :definition_source, :definition_url, :type, :type_long, :results, :related_topics
+    attr_reader :abstract, :abstract_text, :abstract_source, :abstract_url, :image, :heading, :answer, :answer_type, :definition, :definition_source, :definition_url, :type, :type_long, :redirect, :results, :related_topics
     
     # Representes a DDG Zero Click Info result
-    def initialize(abstract = nil, abstract_text = nil, abstract_source = nil, abstract_url = nil, image = nil, heading = nil, answer = nil, answer_type = nil, definition = nil, definition_source = nil, definition_url = nil, type = nil, results = nil, related_topics = nil)
+    def initialize(abstract = nil, abstract_text = nil, abstract_source = nil, abstract_url = nil, image = nil, heading = nil, answer = nil, answer_type = nil, definition = nil, definition_source = nil, definition_url = nil, type = nil, redirect = nil, results = nil, related_topics = nil)
       @abstract = abstract
       @abstract_text = abstract_text
       @abstract_source = abstract_source
@@ -32,6 +32,7 @@ module DuckDuckGo
       @definition_url = definition_url
       @type = type unless type.nil?
       @type_long = TYPE_DEFINITIONS[type]
+      @redirect = redirect
       @results = results
       @related_topics = related_topics
     end
@@ -51,6 +52,7 @@ module DuckDuckGo
       definition_source = result['DefinitionSource'] unless result['DefinitionSource'].empty?
       definition_url = URI.parse(URI.escape(result['DefinitionURL'])) unless result['DefinitionURL'].empty?
       type = result['Type'] unless result['Type'].empty?
+      redirect = result['Redirect'] unless result['Redirect'].empty?
       
       if result['Results']
         results = Array.new
@@ -75,7 +77,7 @@ module DuckDuckGo
         end
       end
       
-      self.new(abstract, abstract_text, abstract_source, abstract_url, image, heading, answer, answer_type, definition, definition_source, definition_url, type, results, related_topics)
+      self.new(abstract, abstract_text, abstract_source, abstract_url, image, heading, answer, answer_type, definition, definition_source, definition_url, type, redirect, results, related_topics)
     end
   end
   

--- a/test/tc_zero_click_info.rb
+++ b/test/tc_zero_click_info.rb
@@ -866,7 +866,7 @@ class TestZCI < Test::Unit::TestCase
     assert_equal("E", zci.type)
     assert_equal("exclusive", zci.type_long)
     assert_nil(zci.answer)
-    assert_nil(ci.abstract_url)
+    assert_nil(zci.abstract_url)
     assert_instance_of(URI::HTTP, zci.redirect)
     assert_equal('en.wikipedia.org', zci.redirect.host)
     assert_equal(0, zci.results.size)

--- a/test/tc_zero_click_info.rb
+++ b/test/tc_zero_click_info.rb
@@ -867,7 +867,7 @@ class TestZCI < Test::Unit::TestCase
     assert_equal("exclusive", zci.type_long)
     assert_nil(zci.answer)
     assert_nil(zci.abstract_url)
-    assert_instance_of(URI::HTTP, zci.redirect)
+    assert_instance_of(URI::HTTPS, zci.redirect)
     assert_equal('en.wikipedia.org', zci.redirect.host)
     assert_equal(0, zci.results.size)
     assert_equal(0, zci.related_topics.size)

--- a/test/tc_zero_click_info.rb
+++ b/test/tc_zero_click_info.rb
@@ -172,6 +172,7 @@ class TestZCI < Test::Unit::TestCase
     "FirstURL"=>"http://duckduckgo.com/c/English_comedians"}],
  "AbstractURL"=>"http://en.wikipedia.org/wiki/Stephen_Fry",
  "Image"=>"http://i.duck.co/i/72880df1.jpg",
+ "Redirect"=>"",
  "DefinitionURL"=>"",
  "DefinitionSource"=>"",
  "AbstractText"=>
@@ -194,6 +195,7 @@ class TestZCI < Test::Unit::TestCase
     assert_nil(zci.answer)
     assert_instance_of(URI::HTTP, zci.abstract_url)
     assert_equal('en.wikipedia.org', zci.abstract_url.host)
+    assert_nil(zci.redirect)
     assert_equal(2, zci.results.size)
     assert_equal("Official site", zci.results[0].text)
     assert_equal(1, zci.related_topics.size)
@@ -453,6 +455,7 @@ class TestZCI < Test::Unit::TestCase
        "FirstURL"=>"http://duckduckgo.com/The_Apple_Tree"}]}],
  "AbstractURL"=>"http://en.wikipedia.org/wiki/Apple_(disambiguation)",
  "Image"=>"",
+ "Redirect"=>"",
  "DefinitionURL"=>
   "http://www.thefreedictionary.com/_/search.aspx?pid=aff18&word=apple",
  "DefinitionSource"=>"TheFreeDictionary",
@@ -475,6 +478,7 @@ class TestZCI < Test::Unit::TestCase
     assert_nil(zci.answer)
     assert_instance_of(URI::HTTP, zci.abstract_url)
     assert_equal('en.wikipedia.org', zci.abstract_url.host)
+    assert_nil(zci.redirect)
     assert_equal(0, zci.results.size)
     assert_equal(10, zci.related_topics.size)
     assert_equal(1, zci.related_topics["_"].size)
@@ -754,6 +758,7 @@ class TestZCI < Test::Unit::TestCase
     "FirstURL"=>"http://duckduckgo.com/Waylon_Smithers"}],
  "AbstractURL"=>"http://en.wikipedia.org/wiki/The_Simpsons_characters",
  "Image"=>"",
+ "Redirect"=>"",
  "DefinitionURL"=>"",
  "DefinitionSource"=>"",
  "AbstractText"=>"",
@@ -773,6 +778,7 @@ class TestZCI < Test::Unit::TestCase
     assert_nil(zci.answer)
     assert_instance_of(URI::HTTP, zci.abstract_url)
     assert_equal('en.wikipedia.org', zci.abstract_url.host)
+    assert_nil(zci.redirect)
     assert_equal(0, zci.results.size)
     assert_equal(1, zci.related_topics.size)
     assert_equal(43, zci.related_topics["_"].size)
@@ -798,6 +804,7 @@ class TestZCI < Test::Unit::TestCase
  "RelatedTopics"=>[],
  "AbstractURL"=>"http://en.wikipedia.org/wiki/Lorem_Ipsum",
  "Image"=>"",
+ "Redirect"=>"",
  "DefinitionURL"=>
   "http://www.merriam-webster.com/dictionary/lorem ipsum",
  "DefinitionSource"=>"TheFreeDictionary",
@@ -819,7 +826,51 @@ class TestZCI < Test::Unit::TestCase
     assert_nil(zci.answer)
     assert_instance_of(URI::HTTP, zci.abstract_url)
     assert_equal('en.wikipedia.org', zci.abstract_url.host)
+    assert_nil(zci.redirect)
     assert_equal(1, zci.results.size)
     assert_equal(0, zci.related_topics.size)
   end
+  
+  def test_zci_redirect
+    
+    data = {"DefinitionSource"=>"",
+ "Heading"=>"",
+ "ImageWidth"=>0,
+ "RelatedTopics"=>[],
+ "Type"=>"E",
+ "Redirect"=>"https://en.wikipedia.org/wiki/Special:Search?search=stephen%20fry&go=Go",
+ "DefinitionURL"=>"",
+ "AbstractURL"=>"",
+ "Definition"=>"",
+ "AbstractSource"=>"",
+ "Infobox"=>"",
+ "Image"=>"",
+ "ImageIsLogo"=>0,
+ "Abstract"=>"",
+ "AbstractText"=>"",
+ "AnswerType"=>"",
+ "ImageHeight"=>0,
+ "Results"=>[],
+ "Answer"=>""}
+ 
+    zci = DuckDuckGo::ZeroClickInfo.by(data)
+    
+    assert_nil(zci.heading)
+    assert_nil(zci.abstract_source)
+    assert_nil(zci.image)
+    assert_nil(zci.abstract_text)
+    assert_nil(zci.definition_source)
+    assert_nil(zci.definition)
+    assert_nil(zci.definition_url)
+    assert_nil(zci.answer_type)
+    assert_equal("E", zci.type)
+    assert_equal("exclusive", zci.type_long)
+    assert_nil(zci.answer)
+    assert_nil(ci.abstract_url)
+    assert_instance_of(URI::HTTP, zci.redirect)
+    assert_equal('en.wikipedia.org', zci.redirect.host)
+    assert_equal(0, zci.results.size)
+    assert_equal(0, zci.related_topics.size)
+  end
+
 end


### PR DESCRIPTION
Hi Andrew,

I suppose you saw my previous pull request (I can't be sure, this is the first time I'm using GitHib, actually).
This time I fixed the issue that made me close the PR.

So I had an issue with the DuckDuckGo `!bang` syntax, which usually redirects to other websites (e.g. https://ddg.gg/?q=!w+duckduckgo redirects to DuckDuckGo on Wikipedia):
`ddg.zeroclickinfo("!w duckduckgo")` would return source HTML from Wikipedia instead of a redirection link from DuckDuckGo.

I fixed it by adding a `no_redirect=1` HTTP argument to the request, based on following API example from the API page: https://api.duckduckgo.com/?q=!imdb+rushmore&format=json&pretty=1&no_redirect=1. `no_redirect=1` is added whether or not !bang syntax is used, but it does not seem to modify anything for other (non-redirected) results.

I also added a `redirect` member to `zeroclickinfo` so as to get this link from DuckDuckGo's answer.
